### PR TITLE
Gestion des libs externes sans intégration directe au dépôt

### DIFF
--- a/external-libs/.gitignore
+++ b/external-libs/.gitignore
@@ -1,0 +1,1 @@
+web-gui-ext-libs.tgz

--- a/external-libs/README.md
+++ b/external-libs/README.md
@@ -1,7 +1,7 @@
 # Common Javascript libs
 Because of the competition context, the web-gui MUST work offline.  
 So external libs MUST be available in a local known location, which is `WEB_ROOT/external-libs-js/` directory.  
-Libs SHOULD be avaliable in full and minified version.  
+Libs SHOULD be available in full and minified version.  
 Current versions SHOULD be avoided to ensure application reliability. Libs update can be done with care.
 
 **Nota Bene :**

--- a/external-libs/README.md
+++ b/external-libs/README.md
@@ -1,6 +1,6 @@
 # Common Javascript libs
-Because of the competition context, the web-gui SHOULD work offline.  
-So external libs SHOULD be available in a local known location, which is `WEB_ROOT/external-libs-js/` directory.  
+Because of the competition context, the web-gui MUST work offline.  
+So external libs MUST be available in a local known location, which is `WEB_ROOT/external-libs-js/` directory.  
 Libs SHOULD be avaliable in full and minified version.  
 Current versions SHOULD be avoided to ensure application reliability. Libs update can be done with care.
 
@@ -12,8 +12,10 @@ On Robotinos, as they work under ubuntu, `WEB_ROOT` will commonly be `/var/www/h
 Please name minified file LIBNAME-version.min.js and uncompressed file LIBNAME-version.js
 
 ## Fetch lib
-***Work In Progress***
+`sudo ./extLibsManager`
+Or `sudo ./extLibsManager -c myLibsArchive.tgz` on a station with web access 
+and then `sudo ./extLibsManager -x myLibsArchive.tgz` on the robot without web access.
 
 ## Update or add libs
-***Work In Progress***  
+Modify the header of `extLibsManager` script.
 Do not remove the first last version. All others older versions can be removed.

--- a/external-libs/README.md
+++ b/external-libs/README.md
@@ -1,0 +1,19 @@
+# Common Javascript libs
+Because of the competition context, the web-gui SHOULD work offline.  
+So external libs SHOULD be available in a local known location, which is `WEB_ROOT/external-libs-js/` directory.  
+Libs SHOULD be avaliable in full and minified version.  
+Current versions SHOULD be avoided to ensure application reliability. Libs update can be done with care.
+
+**Nota Bene :**
+On Robotinos, as they work under ubuntu, `WEB_ROOT` will commonly be `/var/www/html`, so libs location will be 
+`/var/www/html/external-libs-js/`.
+
+## Naming
+Please name minified file LIBNAME-version.min.js and uncompressed file LIBNAME-version.js
+
+## Fetch lib
+***Work In Progress***
+
+## Update or add libs
+***Work In Progress***  
+Do not remove the first last version. All others older versions can be removed.

--- a/external-libs/extLibsManager
+++ b/external-libs/extLibsManager
@@ -144,6 +144,9 @@ makeTarball()
 
 	echo "done"
 
+	# Exit on errors
+	set -e
+
 	# Remove temp dir
 	rm -rf $TMP_DIR
 
@@ -209,6 +212,9 @@ deployFromTarball()
 	# Make dest dir
 	mkdir -p $EXT_LIBS_DEST
 	rm -rf $EXT_LIBS_DEST/*
+
+	# Back to normal
+	set +e
 
 	# Extract libs from archive
 	tar --extract --file $TARBALL_FN --directory $EXT_LIBS_DEST_ROOT

--- a/external-libs/extLibsManager
+++ b/external-libs/extLibsManager
@@ -1,0 +1,313 @@
+#!/bin/bash
+
+#####################################################################
+
+## Libraries
+# (MUST follows the format url|name)
+declare -a LIBS_INFOS
+
+# JQuery and Jquery UI
+LIBS_INFOS[${#LIBS_INFOS[*]}]='http://code.jquery.com/jquery-2.2.4.js|jquery-2.2.4.js'
+LIBS_INFOS[${#LIBS_INFOS[*]}]='http://code.jquery.com/jquery-2.2.4.min.js|jquery-2.2.4.min.js'
+LIBS_INFOS[${#LIBS_INFOS[*]}]='http://code.jquery.com/ui/1.11.4/jquery-ui.js|jquery-ui-1.11.4.js'
+LIBS_INFOS[${#LIBS_INFOS[*]}]='http://code.jquery.com/ui/1.11.4/jquery-ui.min.js|jquery-ui-1.11.4.min.js'
+
+# RoslibJS
+LIBS_INFOS[${#LIBS_INFOS[*]}]='http://cdn.robotwebtools.org/roslibjs/0.15.0/roslib.js|roslib-0.15.0.js'
+LIBS_INFOS[${#LIBS_INFOS[*]}]='http://cdn.robotwebtools.org/roslibjs/0.15.0/roslib.min.js|roslib-0.15.0.min.js'
+# XXX: Find a fixed version link
+LIBS_INFOS[${#LIBS_INFOS[*]}]='http://cdn.robotwebtools.org/EventEmitter2/current/eventemitter2.js|eventemitter-2.js'
+LIBS_INFOS[${#LIBS_INFOS[*]}]='http://cdn.robotwebtools.org/EventEmitter2/current/eventemitter2.min.js|eventemitter-2.min.js'
+
+
+#####################################################################
+
+
+
+## Constants
+EXT_LIBS_DEST_ROOT=/
+EXT_LIBS_DEST_LDIR=var/www/html/external-libs-js
+EXT_LIBS_DEST="$EXT_LIBS_DEST_ROOT/$EXT_LIBS_DEST_LDIR"
+DEFAUTLT_TARBALL_FN=web-gui-ext-libs.tgz
+TMP_DIR="tmp.$RANDOM/"
+
+ACTION_MAKE_TARBALL=0
+ACTION_DEPLOY_FROM_WEB=1
+ACTION_DEPLOY_FROM_TARBALL=3
+
+## GlobalVars
+MISSING_REQUIRED=0
+ACTION=$ACTION_DEPLOY_FROM_WEB
+TARBALL_FN=$DEFAUTLT_TARBALL_FN
+
+
+## Functions
+checkRequired()
+{
+	CMD=$1
+
+	hash $CMD
+	if [ $? -ne 0 ]; then
+		echo "Missing required binary $CMD"
+		MISSING_REQUIRED=1
+	fi
+}
+
+usage()
+{
+	echo    "Usage: $0 [OPTIONS]"
+	echo    "Fetch external javascripts libs from web and deploy them to local directory"
+	echo    ""
+	echo    "Options:"
+	echo -e "  -c [filename]\t\tInstead of deploying locally, save libs into <filename> archive for later deployment"
+	echo -e "\t\t\tIf no <filename> is given, libs will be saved to $DEFAUTLT_TARBALL_FN"
+	echo -e "  -x <filename>\t\tInstead of fetching libs from web, use libs previously saved into <filename> with -c option."
+	echo -e "  -h \t\t\tPrint this help"
+}
+
+fetchLibsFromWeb()
+{
+	echo "Fetching libs from web"
+
+	local NO_ERROR=1
+
+	# Exit on errors
+	set -e
+
+	# Make temporary dir
+	mkdir -p $TMP_DIR/$EXT_LIBS_DEST_LDIR
+
+	# Back to normal
+	set +e
+
+	# Fetch each libs
+	for LIB_INFO in ${LIBS_INFOS[*]} ; do
+		URL=$(echo $LIB_INFO | cut -d\| -f 1)
+		LIB_LFN=$(echo $LIB_INFO | cut -d\| -f 2)
+		LIB_FN="$TMP_DIR/$EXT_LIBS_DEST_LDIR/$LIB_LFN"
+		echo -n " * Fetching $LIB_FN from $URL ... "
+		wget --quiet --output-document=$LIB_FN --retry-connrefused --tries=11 $URL \
+		&& chmod 440 $LIB_FN && chown www-data $LIB_FN
+		if [ $? -ne 0 ]; then
+			echo "fail"
+			NO_ERROR=0
+		else
+			echo "done"
+		fi
+	done
+
+	# Clean and exit if some libs were not correctly fetched
+	if [ $NO_ERROR -ne 1 ]; then
+		echo "[ERROR] Failed fetching some libs"
+		rm -rf "$TMP_DIR"
+		exit 5
+	fi
+}
+
+deployFromWeb()
+{
+	fetchLibsFromWeb
+	echo -n "Deploy to $EXT_LIBS_DEST ... "
+
+	# Exit on errors
+	set -e
+
+	# Make dest dir
+	mkdir -p $EXT_LIBS_DEST
+	rm -rf $EXT_LIBS_DEST/*
+
+	# Deploy
+	mv --force $TMP_DIR/$EXT_LIBS_DEST_LDIR/* $EXT_LIBS_DEST
+
+	# Remove temp dir
+	rm -rf $TMP_DIR
+
+	# Back to normal
+	set +e
+	echo "done"
+}
+
+makeTarball()
+{
+	fetchLibsFromWeb
+	echo -n "Make tarball $TARBALL_FN ... "
+
+	# Create archive
+	tar --create --gzip --file $TARBALL_FN --directory $TMP_DIR $EXT_LIBS_DEST_LDIR
+
+	# Clean and exit if preceding command failed
+	if [ $? -ne 0 ]; then
+		echo "[ERROR] Failed creating archive"
+		rm -rf "$TMP_DIR"
+		exit 6
+	fi
+
+	echo "done"
+
+	# Remove temp dir
+	rm -rf $TMP_DIR
+
+	# Back to normal
+	set +e
+}
+
+checkTarball()
+{
+	local WRONG_PATH
+	local ALL_PATH
+	local MISSING_LIBS
+
+	echo -n "Check tarball validity ... "
+
+	# Exit on errors
+	set -e
+
+	# File exists and regular ?
+	if [ ! -f $TARBALL_FN ]; then
+		echo "[ERROR] Can't find $TARBALL_FN of file is not a regular one"
+		exit 4
+	fi
+
+	# Does it contains wrong path ?
+	WRONG_PATH=$(tar --list --file $TARBALL_FN | grep -v "$EXT_LIBS_DEST_LDIR/[^/]*$"; true)
+	if [ -n "$WRONG_PATH" ]; then
+		echo "[ERROR] $TARBALL_FN is corrupted. The following paths are invalid : "
+		echo "$WRONG_PATH"
+		exit 9
+	fi
+
+	# Are some lib missing ?
+	# XXX: Maybe stop deployment unless a -f (force) argument is given
+	ALL_FN=$(tar --list --file $TARBALL_FN)
+	for LIB_INFO in ${LIBS_INFOS[*]} ; do
+		LIB_LFN=$(echo $LIB_INFO | cut -d\| -f 2)
+		LIB_FN="$EXT_LIBS_DEST_LDIR/$LIB_LFN"
+		if [[ ! $ALL_FN == *"$LIB_FN"* ]];then
+			MISSING_LIBS+="[Warning] Missing $LIB_FN\n"
+		fi
+	done
+
+	# Back to normal
+	set +e
+
+	if [ -n "$MISSING_LIBS" ]; then
+		echo "warn"
+		echo -e $MISSING_LIBS
+	else
+		echo "done"
+	fi
+}
+
+deployFromTarball()
+{
+	checkTarball
+	echo -n "Deploy from tarball $TARBALL_FN ... "
+
+	# Exit on errors
+	set -e
+
+	# Make dest dir
+	mkdir -p $EXT_LIBS_DEST
+	rm -rf $EXT_LIBS_DEST/*
+
+	# Extract libs from archive
+	tar --extract --file $TARBALL_FN --directory $EXT_LIBS_DEST_ROOT
+
+	# Clean and exit if preceding command failed
+	if [ $? -ne 0 ]; then
+		echo "[ERROR] Failed creating archive"
+		rm -rf "$TMP_DIR"
+		exit 6
+	fi
+
+	echo "done"
+}
+
+
+## Main
+# Check that required binaries are installed
+checkRequired id
+checkRequired wget
+checkRequired cut
+checkRequired tar
+checkRequired chmod
+checkRequired chown
+checkRequired mkdir
+checkRequired mv
+checkRequired rm
+
+if [ $MISSING_REQUIRED -eq 1 ]; then
+	echo "[ERROR] Some required binaries are missing, please install them"
+	exit 2
+fi
+
+
+# Manage options
+if [ $# -gt 2 ]; then
+	echo "[ERROR] Too many arguments"
+	echo ""
+	usage
+	exit 1
+fi;
+
+if [ $# -ne 0 ]; then
+	case $1 in
+		-c )
+			if [ $# -eq 2 ]; then
+				TARBALL_FN=$2
+			fi
+			ACTION=$ACTION_MAKE_TARBALL
+			;;
+
+		-x )
+			if [ $# -ne 2 ]; then
+				echo "[ERROR] Missing argument <filename>"
+				echo ""
+				usage
+				exit 1
+			fi
+			TARBALL_FN=$2
+			ACTION=$ACTION_DEPLOY_FROM_TARBALL
+			;;
+
+		* )
+			echo "[ERROR] Wrong arguments given"
+			echo ""
+			usage
+			exit 1
+			;;
+	esac
+fi
+
+
+# MUST be root
+# XXX: Only test if user has needed rights for destination directory and www-data group
+if [ $(id -u) -ne 0 ]; then
+	echo    "[ERROR] Must be run as root. Please retry with : "
+	echo    ""
+	echo -e "sudo $0 $*"
+	exit 10
+fi
+
+
+# Do the work !
+case $ACTION in
+	$ACTION_DEPLOY_FROM_WEB )
+		deployFromWeb
+		;;
+
+	$ACTION_MAKE_TARBALL )
+		makeTarball
+		;;
+
+	$ACTION_DEPLOY_FROM_TARBALL )
+		deployFromTarball
+		;;
+
+	* )
+		echo "[INTERNAL ERR] Unknown action"
+		exit 3
+		;;
+esac
+
+exit 0

--- a/rosbridge.html
+++ b/rosbridge.html
@@ -4,56 +4,36 @@
 <meta charset="utf-8" />
 
 
+<!-- External Libs - Uncompressed (Useful for debug) -->
+<script type="text/javascript" src="/external-libs-js/eventemitter-2.js"></script>
+<script type="text/javascript" src="/external-libs-js/roslib-0.15.0.js"></script>
 
-<!--
-<script type="text/javascript" src="http://cdn.robotwebtools.org/EventEmitter2/current/eventemitter2.js"></script>
-<script type="text/javascript" src="http://cdn.robotwebtools.org/roslibjs/current/roslib.js"></script>
+<script type="text/javascript" src="/external-libs-js/jquery-2.2.4.js"></script>
+<script type="text/javascript" src="/external-libs-js/jquery-ui-1.11.4.js"></script>
 
-A remplacer par un git clone de 
+<!-- External Libs - Minified -->
+<!-- <script type="text/javascript" src="/external-libs-js/eventemitter-2.min.js"></script>
+<script type="text/javascript" src="/external-libs-js/roslib-0.15.0.min.js"></script>
 
-https://github.com/RobotWebTools/roslibjs.git roslibjs/build/roslib.js
-<script type="text/javascript" src="roslibjs/build/roslib.js"></script>
-et 
-https://github.com/asyncly/EventEmitter2.git
-<script type="text/javascript" src="EventEmitter2/lib/eventemitter2.js"></script>
+<script type="text/javascript" src="/external-libs-js/jquery-2.2.4.min.js"></script>
+<script type="text/javascript" src="/external-libs-js/jquery-ui-1.11.4.min.js"></script> -->
 
-<script src="http://code.jquery.com/jquery-1.10.2.js"></script>
-<script src="http://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
-dans le dossier ou sont stocker les pages js
-
-<script type="text/javascript" src="http://cdn.robotwebtools.org/mjpegcanvasjs/current/mjpegcanvas.js"></script>
-<link type="text/css" rel="stylesheet" href="css/style_Ltabs.css" />-->
-
-<script type="text/javascript" src="local/eventemitter2.js"></script>
-<script type="text/javascript" src="local/roslib.js"></script>
-
-<script src="http://code.jquery.com/jquery-2.2.3.js"></script>
-<script type="text/javascript" src="local/jQuery UI - v1.11.4 - 2015-03-11.js"></script>
-
+<!-- Stylesheets -->
 <link type="text/css" rel="stylesheet" href="css/style_Rtabs.css" />
 <link type="text/css" rel="stylesheet" href="css/style.css" />
 
-<!--<script src="http://cdn.robotwebtools.org/EaselJS/current/easeljs.js"></script>
-<script type="text/javascript" src="http://cdn.robotwebtools.org/ros2djs/current/ros2d.js"></script>
-
-<script type="text/javascript" src="local/jQueryLibraryV1.10.2.js"></script>
-
-<link rel="stylesheet" href="http://code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">/-->
-
-
-
+<!-- Local libs -->
 <script type="text/javascript" src="ros.js"></script>
 <script type="text/javascript" src="form.js"></script>
 <script type="text/javascript" src="tabs.js"></script>
 <script type="text/javascript" src="tab1.js"></script>
 
-	
+
 <script type="text/javascript">
 
-
-function reloadTabs() 
+function reloadTabs()
 {
-	$('.tabs .tab-links a').on('click', function(e)  
+	$('.tabs .tab-links a').on('click', function(e)
 	{
 		var currentAttrValue = $(this).attr('href');
 
@@ -72,9 +52,9 @@ function reloadTabs()
 	});
 }
 
-$('#permanent_topic_name').keypress(function(event) 
+$('#permanent_topic_name').keypress(function(event)
 {
-    if (event.which == 13) 
+    if (event.which == 13)
     {
         event.preventDefault();
         createLiveSpace(document.getElementById("permanent_robot_name").value,document.getElementById("permanent_topic_name").value);
@@ -84,12 +64,11 @@ $('#permanent_topic_name').keypress(function(event)
 $(document).ready(reloadTabs);
 
 
+</script>
 
-
-</script>    
 
 </head>
-<body onload="Liste.options[0].selected = true; openSession();" onunload="closeSession();"> 
+<body onload="Liste.options[0].selected = true; openSession();" onunload="closeSession();">
 
   	<header style="margin-top: 0px; margin-bottom: 10px;">  <!-- options disponibles en permanences-->
 		<form method="post" action="#">
@@ -115,7 +94,7 @@ $(document).ready(reloadTabs);
 			<option value="topicSubscriber">Subscribe to a topic
 			<option value="serviceCall">Call a service
 			<option value="paramSetGet">Set and get Param
-			<option value="test">Test	
+			<option value="test">Test
 			</SELECT>
 			<br>
 			<div class="ui-widget">
@@ -123,9 +102,9 @@ $(document).ready(reloadTabs);
 				<br>
 				<input type="text" id="echange2" value="" placeholder="" size="25">
 				<br>
-				<br>	
+				<br>
 			</div>
-	
+
 			<!--<textarea name="message" id="echange3" rows=4 cols=40></textarea>
 			<br>-->
 			<button onclick="lecture();" type="button" id="envoyer" value="envoyer" title="Envoyer">Envoyer</button>
@@ -133,15 +112,15 @@ $(document).ready(reloadTabs);
 		</form>
 		<div id="echange_interactif">
 		</div>
-	</div> 	
+	</div>
  	<div id="container">
  		<!--ongelts generaux-->
  		<div class="tabs" id="Ltabs">
- 			<ul class="tab-links"> 
+ 			<ul class="tab-links">
 		       <li class="active"><a href="#Ltabs-1">test 1</a></li>
 		       <li class=""><a href="#Ltabs-2">test 2</a></li>
 		    </ul>
-		    <div class="tab-content">		    
+		    <div class="tab-content">
 			  	<div id="Ltabs-1" class="tab active">
 			  		<input type="text" id="permanent_robot_name" value="" class="ui-autocomplete-input" placeholder="Nom du robot" size="25" onblur="completeTopics()">
 			  		<input type="text" id="permanent_topic_name" value="" class="ui-autocomplete-input" placeholder="Topic cible" size="25">
@@ -152,14 +131,14 @@ $(document).ready(reloadTabs);
 				</div>
 			</div>
  		</div>
- 			
+
  		<!-- onglets robot -->
  		<div class="tabs" id="Rtabs">
- 			<ul class="tab-links"> 
+ 			<ul class="tab-links">
  				<li class="active"><a href="#Rtabs-1">Cmd 3 Robots</a></li>
  			</ul>
  			<div class="tab-content">
-	 			
+
 	 			<div id="Rtabs-1" class="tab active">
 	 				<legend>Echange commun</legend>
 	 				<fieldset style="height:150px; overflow-y: scroll;" >
@@ -175,7 +154,7 @@ $(document).ready(reloadTabs);
 							<option value="topicSubscriber">Subscribe to a topic
 							<option value="serviceCall">Call a service
 							<option value="paramSetGet">Set and get Param
-							<option value="test">Test	
+							<option value="test">Test
 						</SELECT>
 						<br>
 						<div class="ui-widget">
@@ -183,9 +162,9 @@ $(document).ready(reloadTabs);
 							<br>
 							<input type="text" id="echange2" value="" placeholder="" size="25">
 							<br>
-							<br>	
+							<br>
 						</div>
-			
+
 					<br>
 					<button onclick="lecture();" type="button" id="envoyer" value="envoyer" title="Envoyer">Envoyer</button>
 					<button onclick="function_test();" type="button" id="test" value="test" title="Test">Test</button>
@@ -196,6 +175,6 @@ $(document).ready(reloadTabs);
 	 		</div>
 		</div>
 	</div>
- 	</div> 	
+ 	</div>
 </body>
 </html>


### PR DESCRIPTION
Comme discuté dans la PR #1, il est nécessaire d'avoir les libs externes en local pour les fois ou l'on travail sans connexion internet (cas de la compétition).

Comme il peut être fastidieux de récupérer localement les libs externes à la main, voilà un script qui le gérera pour nous. On a en plus la possibilité de générer une archive qu'on peut garder sur clé USB par exemple pour redéployer les libs lorsqu’on n'a déjà plus de connexion internet.

Il y a encore des améliorations possibles, c'est certains. Comme moi j'étais plutôt parti pour bêtement intégrer le code dans nos dépôts au départ - chose facile mais contraire à nos pratiques - je ne pense pas nécessaire de beaucoup plus améliorer tout ça.
Ce qui compte, c'est que ça fonctionne tout le temps. 

Exemple d'améliorations : 
- avoir les libs et leur URL dans un fichier plutôt que dans le script
- ne pas supprimer une ancienne lib du dossier local quand est elle absente de l'archive (on la perdrait à jamais)
- ne pas demander systématiquement les droits `root`, si le système est bien configuré peut-être que les droits ne sont pas nécessaire

Je peux avoir oublié des choses, fait des âneries, etc, je compte pas mal sur la revue pour rattraper ça :neutral_face: 
